### PR TITLE
Support multiple zones/hosts, add LuaDNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,29 @@ ddnsc support few linux package managers to make it easy to install.
 | DISTRO         |  REPO                                          |  VERSION  |
 |----------------|------------------------------------------------|:---------:|
 |  Arch          | [aur](//aur.archlinux.org/packages/ddnsc)      | v1.0.0    |
+
+## Configuration
+
+Multiple DNS providers, domains, and hosts/subdomains are supported. The configuration file has the following format:
+
+```
+[global]
+intervel=300
+use=web
+
+[example.com]
+provider=LuaDNS
+email=EMAIL
+key=KEY
+hosts=@,blah,bazz
+ttl=200
+
+[bar.com]
+provider=LuaDNS
+email=EMAIL
+key=KEY
+hosts=@,foo
+ttl=600
+```
+
+The `global` section is required, and an arbitrary number of subsequent sections after that are supported where each section title is the zone/domain to update. Hosts/subdomains to update are listed under each section. The `@` denotes updating the zone/domain itself. If the `@` were omitted from the `[example.com]` section in the example above, then only the A records for blah.example.com and bazz.example.com would be updated, and the A record for `example.com` would *not* be updated.

--- a/ddnsc.py
+++ b/ddnsc.py
@@ -29,6 +29,9 @@ if __name__ == '__main__':
             module = __import__("plugins." + section, fromlist=[section])
             instance = getattr(module, section)(config)
             instance.worker()
+    update_interval_sec = config['global'].get('interval')
+    if not update_interval_sec:
+        update_interval_sec = 300
 
 
-        time.sleep( int(config['global'].get('interval')) )
+        time.sleep(update_interval_sec)

--- a/ddnsc.py
+++ b/ddnsc.py
@@ -20,18 +20,22 @@ if __name__ == '__main__':
     # NOTIFY ( systemd )
     systemd.daemon.notify('READY=1')
 
-    while True:   
-
-        for section in config.sections():
-            if section == 'global': continue
-
-            # DUNAMIC PLUGIN
-            module = __import__("plugins." + section, fromlist=[section])
-            instance = getattr(module, section)(config)
-            instance.worker()
+    zones = {}
+    for zone in config.sections():
+        if zone == 'global':
+            continue
+        provider = config[zone].get('provider')
+        try:
+            module = __import__("plugins." + provider, fromlist=[provider])
+        except ImportError:
+            print(f"ERROR: Unknown provider in zone '{zone}': {provider}")
+        zones[zone] = getattr(module, provider)(zone, config[zone])
     update_interval_sec = config['global'].get('interval')
     if not update_interval_sec:
         update_interval_sec = 300
 
+    while True:
+        for _, zone_invoke in zones.items():
+            zone_invoke.worker()
 
         time.sleep(update_interval_sec)

--- a/ddnsc.py
+++ b/ddnsc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import time, configparser, systemd.daemon, requests
 
 # PLUGINS

--- a/helpers/IP.py
+++ b/helpers/IP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, requests
 

--- a/helpers/rest_provider.py
+++ b/helpers/rest_provider.py
@@ -1,0 +1,45 @@
+import json
+import requests
+
+
+class RestProvider:
+    def __init__(self, base_url, auth, headers):
+        self.base_url = base_url
+        self.headers = headers
+        self.auth = auth
+
+    def get(self, endpoint):
+        """
+        :param endpoint: REST API endpoint to GET
+        :returns: dict representing json response. If error, returns None
+        """
+        try:
+            res = requests.get(f"{self.base_url}/{endpoint}",
+                               auth=self.auth, headers=self.headers)
+            if res.status_code != 200:
+                print(f"ERROR: Status code is {res.status_code}. "
+                      f"Response: {res.text}")
+                return None
+        except requests.exceptions.RequestException as e:
+            print(f"ERROR: Request failed: {e}")
+            return None
+        return res.json()
+
+    def put(self, endpoint, data):
+        """
+        :param endpoint: REST API endpoint to GET
+        :param data: dict of data to send (as json)
+        :returns: True if succesful, else False
+        """
+        try:
+            res = requests.put(f"{self.base_url}/{endpoint}",
+                               headers=self.headers, auth=self.auth,
+                               data=json.dumps(data))
+            if res.status_code != 200:
+                print(f"ERROR: Status code is {res.status_code}. "
+                      f"Response: {res.text}")
+                return False
+        except requests.exceptions.RequestException as e:
+            print(f"ERROR: Request failed: {e}")
+            return False
+        return True

--- a/plugins/CloudFlare.py
+++ b/plugins/CloudFlare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, requests, json
 from systemd import journal

--- a/plugins/Example.py
+++ b/plugins/Example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 class Example:
 
     def __init__(self, config):

--- a/plugins/LuaDNS.py
+++ b/plugins/LuaDNS.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from requests.auth import HTTPBasicAuth
+
+# HELPERS
+from helpers.IP import IP
+from helpers.rest_provider import RestProvider
+
+
+class LuaDNS:
+
+    # PROPS
+    config = None
+    headers = {
+        "Accept": "application/json"
+    }
+    ip = {
+        "public": None
+    }
+
+    # CONSTRUCTOR
+    def __init__(self, zone, config):
+        self.config = config
+        self.zone = zone
+        self.rest = RestProvider("https://api.luadns.com/v1",
+                                 auth=HTTPBasicAuth(self.config.get('email'),
+                                                    self.config.get('key')),
+                                 headers=self.headers)
+        self._zone_records = {}
+        self._zones = {}
+        self.setPublicIp()
+        self.zones = self._get_zones()
+
+    def setPublicIp(self):
+        self.ip['public'] = IP().getPublic()
+
+    def worker(self):
+        hosts = self.config['hosts'].split(',')
+        host_records = self._get_records(self.zones[self.zone])
+        put_url = f"zones/{self.zones[self.zone]}/records"
+        for host in hosts:
+            if host == '@':
+                host = self.zone
+            if not host.endswith('.'):
+                host += '.'
+            if host not in host_records:
+                print(f"WARN: Attempted to update host '{host}' that is not "
+                      "found under this account!")
+                continue
+            data = {
+                "type": "A",
+                "name": host,
+                "content": self.ip['public'],
+                "ttl": 120}
+            ret = self.rest.put(f"{put_url}/{host_records[host]}", data)
+            if not ret:
+                print(f"ERROR: Unable to update host record for '{host}' at "
+                      "zone '{self.zone}'")
+                continue
+
+    def _get_records(self, zone_id):
+        """
+        :param zone_id: integer zone ID for luaDNS zone to fetch records from
+        :returns: dict where record name is key record id is val.
+        """
+        if zone_id not in self._zone_records:
+            r_list = self.rest.get(f"zones/{zone_id}")
+            if r_list:
+                self._zone_records = {r['name']: r['id'] for r in r_list['records'] if r['type'].lower() == 'a'}
+        return self._zone_records
+
+    def _get_zones(self):
+        """
+        :returns: dict where zone name is key and zone id is val.
+        """
+        if not self._zones:
+            z_list = self.rest.get("zones")
+            if z_list:
+                self._zones = {z['name']: z['id'] for z in z_list}
+        return self._zones


### PR DESCRIPTION
Note that I haven't updated the CloudFlare plugin to work with this yet, since I don't have an account there and no way to test it. I'll probably need some help fixing that.

Fixes #2 

Here's an example config file that works with this change:

```
[global]
intervel=300
use=web

[example.com]
provider=LuaDNS
email=EMAIL
key=KEY
hosts=@,blah,bazz
ttl=200

[bar.com]
provider=LuaDNS
email=EMAIL
key=KEY
hosts=@,foo
ttl=600
```

This will update `foo.bar.com`, `foo.com`, `example.com`, `blah.example.com`, and `bazz.example.com` using the LuaDNS plugin. The `@` represents the A record for the zone itself (e.g. `example.com`). If that were omitted from the two examples above, then the A record for `bar.com` and `example.com` would *not* be updated (but the A record for the subdomains would be). 