### PR TITLE
Do not make API calls to providers if IP address hasn't changed

### DIFF
--- a/ddnsc.py
+++ b/ddnsc.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import time, configparser, systemd.daemon, requests
 
+from helpers.IP import IP
+
 if __name__ == '__main__':
 
     '''
@@ -44,9 +46,13 @@ if __name__ == '__main__':
     update_interval_sec = config['global'].get('interval')
     if not update_interval_sec:
         update_interval_sec = 300
-
+    
+    ip = None
     while True:
-        for _, zone_invoke in zones.items():
-            zone_invoke.worker()
-
+        new_ip = IP.getPublic()
+        if not ip or ip != new_ip:
+            ip = new_ip
+            print(f"INFO: IP changed, updating zones/hosts with IP: {new_ip}")
+            for _, zone_invoke in zones.items():
+                zone_invoke.worker(ip)
         time.sleep(int(update_interval_sec))

--- a/ddnsc.py
+++ b/ddnsc.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 import time, configparser, systemd.daemon, requests
 
-# PLUGINS
-from plugins.CloudFlare import CloudFlare
-
 if __name__ == '__main__':
 
     '''

--- a/helpers/IP.py
+++ b/helpers/IP.py
@@ -13,5 +13,6 @@ class IP:
                 ip = response.json()
                 return ip['ip']
         except requests.exceptions.RequestException as e:
+            print("ERROR: Unable to get public IP address!")
             print( e )
             sys,exit(1)

--- a/helpers/IP.py
+++ b/helpers/IP.py
@@ -4,6 +4,7 @@ import sys, requests
 
 class IP:
 
+    @staticmethod
     def getPublic(self):
 
         try:

--- a/plugins/CloudFlare.py
+++ b/plugins/CloudFlare.py
@@ -16,23 +16,11 @@ class CloudFlare:
         "X-Auth-Email": None,
         "X-Auth-Key": None
     }
-    ip = {
-        "public": None
-    }
-
 
     # CONSTRUCTOR
     def __init__(self, zone, config):
         self.zone = zone
         self.config = config
-
-
-        '''
-        Need to configure the current public IP
-        before the update process begin.
-        '''
-        self.ip['public'] = IP().getPublic()
-
 
         '''
         Need to configure CloudFlare request headers
@@ -64,7 +52,9 @@ class CloudFlare:
                     "type": "A",
                     "id": id_list['result'][0]['id'],
                     "name": host + '.' + self.config.name,
-                    "content": self.ip['public'],
+                    # Note: 'content' will be set in the worker method before
+                    # sending request
+                    "content": None,
                     "ttl": 120,
                     "proxied": False
                 })
@@ -73,6 +63,7 @@ class CloudFlare:
 
 
     # WORKER
-    def worker(self):
+    def worker(self, ip):
         for host in self.records:
+            host['content'] = ip
             self.rest.put('/zones/' + self.config.get('zone') + '/dns_records/' + host['id'], host)

--- a/plugins/Example.py
+++ b/plugins/Example.py
@@ -5,5 +5,8 @@ class Example:
         print( config )
 
 
-    def worker(self):
-        print("Example::worker")
+    def worker(self, ip):
+        """
+        :param ip: str IPv4 address to use in the request to update
+        """
+        print(f"Example::worker using IP {ip}")

--- a/plugins/LuaDNS.py
+++ b/plugins/LuaDNS.py
@@ -2,7 +2,6 @@
 from requests.auth import HTTPBasicAuth
 
 # HELPERS
-from helpers.IP import IP
 from helpers.rest_provider import RestProvider
 
 
@@ -12,9 +11,6 @@ class LuaDNS:
     config = None
     headers = {
         "Accept": "application/json"
-    }
-    ip = {
-        "public": None
     }
 
     # CONSTRUCTOR
@@ -27,13 +23,9 @@ class LuaDNS:
                                  headers=self.headers)
         self._zone_records = {}
         self._zones = {}
-        self.setPublicIp()
         self.zones = self._get_zones()
 
-    def setPublicIp(self):
-        self.ip['public'] = IP().getPublic()
-
-    def worker(self):
+    def worker(self, ip):
         hosts = self.config['hosts'].split(',')
         host_records = self._get_records(self.zones[self.zone])
         put_url = f"zones/{self.zones[self.zone]}/records"
@@ -49,7 +41,7 @@ class LuaDNS:
             data = {
                 "type": "A",
                 "name": host,
-                "content": self.ip['public'],
+                "content": ip,
                 "ttl": 120}
             ret = self.rest.put(f"{put_url}/{host_records[host]}", data)
             if not ret:


### PR DESCRIPTION
This is my attempt to fix #1. 

It works with LuaDNS, but I am not able to test CloudDNS. Note that the interface to `plugins.<provider>.worker()` has changed with this merge request to accept an `ip` str value.