### PR TITLE
luadns: fix bug with hosts not being found in the list of records

### DIFF
--- a/plugins/LuaDNS.py
+++ b/plugins/LuaDNS.py
@@ -40,6 +40,8 @@ class LuaDNS:
         for host in hosts:
             if host == '@':
                 host = self.zone
+            else:
+                host += '.' + self.zone
             if not host.endswith('.'):
                 host += '.'
             if host not in host_records:


### PR DESCRIPTION
I forgot to append the zone name to the host for matching the record
returned by the luadns API, this fixes that mistake.