### PR TITLE
Support systems without systemd

### DIFF
--- a/ddnsc.py
+++ b/ddnsc.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
-import time, configparser, systemd.daemon, requests
+import time, configparser, requests
 
 from helpers.IP import IP
+
+try:
+    import systemd.daemon
+    has_systemd = True
+except ImportError:
+    has_systemd = False
 
 if __name__ == '__main__':
 
@@ -17,7 +23,8 @@ if __name__ == '__main__':
     config.read('/etc/ddnsc/ddnsc.conf')
 
     # NOTIFY ( systemd )
-    systemd.daemon.notify('READY=1')
+    if has_systemd:
+        systemd.daemon.notify('READY=1')
 
     zones = {}
     for zone in config.sections():

--- a/ddnsc.py
+++ b/ddnsc.py
@@ -2,6 +2,7 @@
 import time, configparser, requests
 
 from helpers.IP import IP
+from helpers.logger import Logger
 
 try:
     import systemd.daemon
@@ -42,7 +43,7 @@ if __name__ == '__main__':
         try:
             module = __import__("plugins." + provider, fromlist=[provider])
         except ImportError:
-            print(f"ERROR: Unknown provider in zone '{zone}': {provider}")
+            Logger.error(f"Unknown provider in zone '{zone}': {provider}")
 
         zones[zone] = getattr(module, provider)(zone, config[zone])
 
@@ -59,7 +60,7 @@ if __name__ == '__main__':
         new_ip = IP.getPublic()
         if not ip or ip != new_ip:
             ip = new_ip
-            print(f"INFO: IP changed, updating zones/hosts with IP: {new_ip}")
+            Logger.info(f"IP changed, updating zones/hosts with IP: {new_ip}")
             for _, zone_invoke in zones.items():
                 zone_invoke.worker(ip)
         time.sleep(int(update_interval_sec))

--- a/helpers/IP.py
+++ b/helpers/IP.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys, requests
+from helpers.logger import Logger
 
 class IP:
 
@@ -13,6 +14,6 @@ class IP:
                 ip = response.json()
                 return ip['ip']
         except requests.exceptions.RequestException as e:
-            print("ERROR: Unable to get public IP address!")
-            print( e )
+            Logger.error("Unable to get public IP address!")
+            Logger.error( e )
             sys,exit(1)

--- a/helpers/http_provider.py
+++ b/helpers/http_provider.py
@@ -1,5 +1,6 @@
 import requests
 from urllib.parse import quote
+from helpers.logger import Logger
 
 
 class HttpProvider:
@@ -21,12 +22,12 @@ class HttpProvider:
             if res.status_code == 200:
                 return res.text
             if res.status_code != 200:
-                print(f"ERROR: Status code is {res.status_code}."
-                      f"Response: {res.text}")
+                Logger.error(f"Status code is {res.status_code}."
+                             f"Response: {res.text}")
                 return None
 
         except requests.exceptions.RequestException as e:
-            print(f"ERROR: Request failed: {e}")
+            Logger.error(f"Request failed: {e}")
             return None
 
     def get_q_string(self, query_string):
@@ -47,10 +48,10 @@ class HttpProvider:
             if res.status_code == 200:
                 return res.text
             if res.status_code != 200:
-                print(f"ERROR: Status code is {res.status_code}."
-                      f"Response: {res.text}")
+                Logger.error(f"Status code is {res.status_code}."
+                             f"Response: {res.text}")
                 return None
 
         except requests.exceptions.RequestException as e:
-            print(f"ERROR: Request failed: {e}")
+            Logger.error(f"Request failed: {e}")
             return None

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -1,0 +1,49 @@
+# Copyright(c) 2021 by craftyguy "Clayton Craft" <clayton@craftyguy.net>
+# Distributed under GPLv3+ (see COPYING) WITHOUT ANY WARRANTY.
+import logging
+import logging.handlers
+
+try:
+    import systemd.journal
+    has_systemd = True
+except ImportError:
+    has_systemd = False
+
+
+class Logger:
+    instance = None
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def get_logger():
+        if Logger.instance is None:
+            new_instance = logging.getLogger("ddnsc")
+
+            if has_systemd:
+                handler = systemd.journal.JournalHandler()
+            else:
+                # fall back to syslog
+                handler = logging.handlers.SysLogHandler(address="/dev/log")
+
+            log_format = logging.Formatter("%(name)s: %(levelname)s "
+                                           "%(message)s")
+            handler.setFormatter(log_format)
+            new_instance.setLevel(logging.INFO)
+            new_instance.addHandler(handler)
+            Logger.instance = new_instance
+
+        return Logger.instance
+
+    @staticmethod
+    def info(msg):
+        Logger.get_logger().info(msg)
+
+    @staticmethod
+    def error(msg):
+        Logger.get_logger().error(msg)
+
+    @staticmethod
+    def warning(msg):
+        Logger.get_logger().warning(msg)

--- a/helpers/rest_provider.py
+++ b/helpers/rest_provider.py
@@ -1,5 +1,6 @@
 import json
 import requests
+from helpers.logger import Logger
 
 
 class RestProvider:
@@ -27,12 +28,13 @@ class RestProvider:
 
 
             if res.status_code != 200:
-                print(f"ERROR: Status code is {res.status_code}." f"Response: {res.text}")
+                Logger.error("ERROR: Status code is {res.status_code}."
+                             f"Response: {res.text}")
                 return None
 
 
         except requests.exceptions.RequestException as e:
-            print(f"ERROR: Request failed: {e}")
+            Logger.error(f"Request failed: {e}")
             return None
 
     def get_json(self, endpoint):
@@ -46,7 +48,7 @@ class RestProvider:
         try:
             json_resp = json.loads(resp)
         except json.JSONDecodeError:
-            print(f"ERROR: Invalid response to request at endpoint {endpoint}")
+            Logger.error(f"Invalid response to request at endpoint {endpoint}")
         return json_resp
 
 
@@ -66,11 +68,11 @@ class RestProvider:
             not eq to 200
             '''
             if Response.status_code != 200:
-                print(f"ERROR: Response code {Response.status_code}")
+                Logger.error(f"Response code {Response.status_code}")
                 return False
 
         except requests.exceptions.RequestException as e:
-            print(f"ERROR: Request failed : {e}")
+            Logger.error(f"Request failed : {e}")
             return False
         finally:
             return True
@@ -86,10 +88,10 @@ class RestProvider:
         try:
             res = requests.put(f"{self.base_url}/{endpoint}", headers=self.headers, auth=self.auth, data=json.dumps(data))
             if res.status_code != 200:
-                print(f"ERROR: Status code is {res.status_code}. "
-                      f"Response: {res.text}")
+                Logger.error(f"Status code is {res.status_code}. "
+                             f"Response: {res.text}")
                 return False
         except requests.exceptions.RequestException as e:
-            print(f"ERROR: Request failed: {e}")
+            Logger.error(f"Request failed: {e}")
             return False
         return True

--- a/plugins/CloudFlare.py
+++ b/plugins/CloudFlare.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import sys, requests
-from systemd import journal
 
 # HELPERS
 from helpers.IP import IP

--- a/plugins/DuckDNS.py
+++ b/plugins/DuckDNS.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-from systemd import journal
 from helpers.rest_provider import RestProvider
+from helpers.logger import Logger
 
 class DuckDNS:
 
@@ -25,5 +25,5 @@ class DuckDNS:
             '''
             Update each host record with the new IP
             '''
-            journal.send(f"[ddnsc]: Updating IP address {ip} to DuckDNS record {host}.{self.config.name}")
+            Logger.Info(f"Updating IP address {ip} to DuckDNS record {host}.{self.config.name}")
             self.rest.get(f"/{host}.{self.config.name}/{self.config.get('token')}/{ip}")

--- a/plugins/Dynu.py
+++ b/plugins/Dynu.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 import json
-from systemd import journal
 from helpers.rest_provider import RestProvider
+from helpers.logger import Logger
+
 
 class Dynu:
 
@@ -60,6 +61,6 @@ class Dynu:
             host['ipv4Address'] = ip
             Response = self.rest.post('/dns/' + str(host['id']), host)
             if Response == True:
-                journal.send(f"[ddnsc]: Updating IP address {ip} to Dynu.net record {host['name']}")
+                Logger.info(f"Updating IP address {ip} to Dynu.net record {host['name']}")
             else:
-                journal.send(f"[ddnsc]: ERROR Updating IP address {ip} to Dynu.net record {host['name']}")
+                Logger.Error(f"Failed to update IP address {ip} to Dynu.net record {host['name']}")

--- a/plugins/Example.py
+++ b/plugins/Example.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
+from helpers.logger import Logger
+
+
 class Example:
 
     def __init__(self, config):
-        print( config )
+        Logger.info(config)
 
 
     def worker(self, ip):
         """
         :param ip: str IPv4 address to use in the request to update
         """
-        print(f"Example::worker using IP {ip}")
+        Logger.info(f"using IP {ip}")

--- a/plugins/FreeDNS.py
+++ b/plugins/FreeDNS.py
@@ -3,6 +3,7 @@ import hashlib
 
 # HELPERS
 from helpers.http_provider import HttpProvider
+from helpers.logger import Logger
 
 
 class FreeDNS:
@@ -31,13 +32,13 @@ class FreeDNS:
             else:
                 host += '.' + self.zone
             if host not in self._zones:
-                print(f"WARN: Attempted to update host '{host}' that is not "
-                      "found under this account!")
+                Logger.warning(f"Attempted to update host '{host}' "
+                               "that is not found under this account!")
                 continue
             ret = HttpProvider.get(self.update_url + host)
             if not ret:
-                print(f"ERROR: Unable to update host record for '{host}' at "
-                      "zone '{self.zone}'")
+                Logger.error("Unable to update host record "
+                             f"for '{host}' at zone '{self.zone}'")
                 continue
 
     def _get_zones(self):

--- a/plugins/LuaDNS.py
+++ b/plugins/LuaDNS.py
@@ -3,6 +3,7 @@ from requests.auth import HTTPBasicAuth
 
 # HELPERS
 from helpers.rest_provider import RestProvider
+from helpers.logger import Logger
 
 
 class LuaDNS:
@@ -44,8 +45,8 @@ class LuaDNS:
             if not host.endswith('.'):
                 host += '.'
             if host not in host_records:
-                print(f"WARN: Attempted to update host '{host}' that is not "
-                      "found under this account!")
+                Logger.warning(f"Attempted to update host '{host}' "
+                               "that is not found under this account!")
                 continue
             data = {
                 "type": "A",
@@ -55,8 +56,8 @@ class LuaDNS:
             }
             ret = self.rest.put(f"{put_url}/{host_records[host]}", data)
             if not ret:
-                print(f"ERROR: Unable to update host record for '{host}' at "
-                      "zone '{self.zone}'")
+                Logger.error(f"Unable to update host record for '{host}' at "
+                             "zone '{self.zone}'")
                 continue
 
     def _get_records(self, zone_id):


### PR DESCRIPTION
This merge request attempts to add support for systemd my changing the logging system to use a singleton logger with a handler selected conditionally. It prefers systemd/journald but will fall back to using the syslog handler if that fails.

Some Linux distros (e.g. Alpine Linux) do not use systemd, so that's the motivation behind this change.

Messages in journald will now look something like: 

```
Oct 30 13:31:41 thinkpad ddnsc.py[469649]: INFO IP changed, updating zones/hosts with IP: 12.34.56.78
Oct 30 13:31:42 thinkpad ddnsc.py[469649]: WARNING Attempted to update host 'example.com.' that is not found under this account!
```


