### PR TITLE
config: fix typo, "intervel"

### DIFF
--- a/.configs/ddnsc.conf
+++ b/.configs/ddnsc.conf
@@ -1,5 +1,5 @@
 [global]
-intervel=300
+interval=300
 use=web
 
 # CloudFlare

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Multiple DNS providers, domains, and hosts/subdomains are supported. The configu
 
 ```
 [global]
-intervel=300
+interval=300
 use=web
 
 [example.com]


### PR DESCRIPTION
I typo'd the name of this... the code is actually looking for the
correct spelling: interval.